### PR TITLE
CMake: target-based GMP finder

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -14,9 +14,18 @@ find_path(GMP_INCLUDE_DIR
   ${INCLUDE_INSTALL_DIR}
 )
 
-find_library(GMP_LIBRARIES gmp PATHS $ENV{GMPDIR} ${LIB_INSTALL_DIR})
+find_library(GMP_LIBRARY gmp PATHS $ENV{GMPDIR} ${LIB_INSTALL_DIR})
+
+find_package_handle_standard_args(GMP DEFAULT_MSG
+                                  GMP_INCLUDE_DIR GMP_LIBRARY)
+
+if(GMP_FOUND AND NOT TARGET GMP::GMP)
+    add_library(GMP::GMP INTERFACE IMPORTED)
+    target_include_directories(GMP::GMP INTERFACE ${GMP_INCLUDE_DIR})
+    target_link_libraries(GMP::GMP INTERFACE ${GMP_LIBRARY})
+endif()
+
+set(GMP_LIBRARIES GMP::GMP)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GMP DEFAULT_MSG
-                                  GMP_INCLUDE_DIR GMP_LIBRARIES)
 mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARIES)

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -20,9 +20,9 @@ find_package_handle_standard_args(GMP DEFAULT_MSG
                                   GMP_INCLUDE_DIR GMP_LIBRARY)
 
 if(GMP_FOUND AND NOT TARGET GMP::GMP)
-    add_library(GMP::GMP INTERFACE IMPORTED)
+    add_library(GMP::GMP UNKNOWN IMPORTED)
     target_include_directories(GMP::GMP INTERFACE ${GMP_INCLUDE_DIR})
-    target_link_libraries(GMP::GMP INTERFACE ${GMP_LIBRARY})
+    set_target_properties(GMP::GMP PROPERTIES IMPORTED_LOCATION ${GMP_LIBRARY})
 endif()
 
 set(GMP_LIBRARIES GMP::GMP)


### PR DESCRIPTION
Hi,
this fixes an issue for me where cmake creates a linker line that just uses `-lgmp` without specifying the link directory. We could also move this to the cmake-library project if you like :)

~~EDIT: Just noticed an issue when self-reviewing, let me fix this quickly.~~ Done.